### PR TITLE
Enable flat mapping

### DIFF
--- a/schema/schema.js
+++ b/schema/schema.js
@@ -15,6 +15,7 @@ const schema = {
             properties: {
               field: { type: 'string', required: true },
               to: { type: 'string' },
+              flatten: {type: 'boolean'},
               fieldset: { $ref: '/Fieldset' }
             }
           }

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -471,3 +471,215 @@ describe('Schema violation errors', () => {
     expect(() => mapToNewObject(source, xFormTemplate)).to.throw(errorMsg);
   });
 });
+
+describe('FromEach mapping to flat object', () => {
+  it("should flatten the next fromEach's fieldset if marked so", () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          fromEach: {
+            field: 'highLevel',
+            to: 'flat',
+            flatten: true,
+            fieldset: [
+              {
+                from: 'fieldOne'
+              },
+              {
+                from: 'fieldTwo'
+              },
+              {
+                fromEach: {
+                  field: 'lowLevel',
+                  fieldset: [
+                    {
+                      from: 'fieldThree'
+                    },
+                    {
+                      from: 'fieldFour'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const source = {
+      highLevel: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          lowLevel: [
+            {
+              fieldThree: 3,
+              fieldFour: 4
+            }
+          ]
+        }
+      ]
+    };
+    const target = {
+      flat: [{ fieldOne: 1, fieldTwo: 2, fieldThree: 3, fieldFour: 4 }]
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it("should flatten only the next fromEach's fieldset and not more than that", () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          fromEach: {
+            field: 'highLevel',
+            to: 'flat',
+            flatten: true,
+            fieldset: [
+              {
+                from: 'fieldOne'
+              },
+              {
+                from: 'fieldTwo'
+              },
+              {
+                fromEach: {
+                  field: 'lowLevel',
+                  fieldset: [
+                    {
+                      from: 'fieldThree'
+                    },
+                    {
+                      from: 'fieldFour'
+                    },
+                    {
+                      fromEach: {
+                        field: 'basement',
+                        fieldset: [
+                          {
+                            from: 'this',
+                            to: 'that'
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const source = {
+      highLevel: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          lowLevel: [
+            {
+              fieldThree: 3,
+              fieldFour: 4,
+              basement: [
+                {
+                  this: 'value'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const target = {
+      flat: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          fieldThree: 3,
+          fieldFour: 4,
+          basement: [{ that: 'value' }]
+        }
+      ]
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+  it("should flatten all fromEach blocks if marked so", () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          fromEach: {
+            field: 'highLevel',
+            to: 'flat',
+            flatten: true,
+            fieldset: [
+              {
+                from: 'fieldOne'
+              },
+              {
+                from: 'fieldTwo'
+              },
+              {
+                fromEach: {
+                  field: 'lowLevel',
+                  flatten: true,
+                  fieldset: [
+                    {
+                      from: 'fieldThree'
+                    },
+                    {
+                      from: 'fieldFour'
+                    },
+                    {
+                      fromEach: {
+                        field: 'basement',
+                        fieldset: [
+                          {
+                            from: 'this',
+                            to: 'that'
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const source = {
+      highLevel: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          lowLevel: [
+            {
+              fieldThree: 3,
+              fieldFour: 4,
+              basement: [
+                {
+                  this: 'value'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const target = {
+      flat: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          fieldThree: 3,
+          fieldFour: 4,
+          that: 'value'
+        }
+      ]
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);    
+  });
+});

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -320,9 +320,7 @@ describe('Testing complex object', () => {
       myProp: 'myValue',
       myField: [
         {
-          myNestedProp: 'myNestedPropValue'
-        },
-        {
+          myNestedProp: 'myNestedPropValue',
           myOtherNestedProp: 'myOtherNestedPropValue'
         }
       ]
@@ -405,34 +403,48 @@ describe('Testing complex object', () => {
 
   it('should correctly map nested fromEach blocks with fieldsets within', () => {
     const xFormTemplate = {
-      fieldset: [{
-        fromEach: {
-          field: 'levelOne',
-          fieldset: [{
-            fromEach: {
-              field: 'array',
-              fieldset: [{
-                from: 'levelTwo'
-              }]
-            }
-          }]
+      fieldset: [
+        {
+          fromEach: {
+            field: 'levelOne',
+            fieldset: [
+              {
+                fromEach: {
+                  field: 'array',
+                  fieldset: [
+                    {
+                      from: 'levelTwo'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
         }
-      }]
+      ]
     };
     const source = {
-      levelOne: [{
-        array: [{
-          levelTwo: 'here\'s level two :2 y\'all!'
-        }]
-      }]
-    }
+      levelOne: [
+        {
+          array: [
+            {
+              levelTwo: "here's level two :2 y'all!"
+            }
+          ]
+        }
+      ]
+    };
     const target = {
-      levelOne: [{
-        array: [{
-          levelTwo: 'here\'s level two :2 y\'all!'
-        }]
-      }]
-    }
+      levelOne: [
+        {
+          array: [
+            {
+              levelTwo: "here's level two :2 y'all!"
+            }
+          ]
+        }
+      ]
+    };
     const newObject = mapToNewObject(source, xFormTemplate);
     expect(newObject).to.eqls(target);
   });
@@ -460,5 +472,61 @@ describe('Schema violation errors', () => {
     const errorMsg =
       'instance.fieldset[0].fromEach.field is required\ninstance.fieldset[0].fromEach.fieldset[0] is not any of [subschema 0],[subschema 1]';
     expect(() => mapToNewObject(source, xFormTemplate)).to.throw(errorMsg);
+  });
+});
+
+describe('FromEach mapping to flat object', () => {
+  it('should map the defined fields into a new object in the target object without inheriting the original structure', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          fromEach: {
+            field: 'highLevel',
+            to: 'flat',
+            flat: true,
+            fieldset: [
+              {
+                from: 'fieldOne'
+              },
+              {
+                from: 'fieldTwo'
+              },
+              {
+                fromEach: {
+                  field: 'lowLevel',
+                  fieldset: [
+                    {
+                      from: 'fieldThree'
+                    },
+                    {
+                      from: 'fieldFour'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const source = {
+      highLevel: [
+        {
+          fieldOne: 1,
+          fieldTwo: 2,
+          lowLevel: [
+            {
+              fieldThree: 3,
+              fieldFour: 4
+            }
+          ]
+        }
+      ]
+    };
+    const target = {
+      flat: [{ fieldOne: 1, fieldTwo: 2, fieldThree: 3, fieldFour: 4 }]
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
   });
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -42,6 +42,7 @@ describe('Successful validations of correct JSON mappings :)', () => {
           to: 'target',
           fromEach: {
             field: 'fromEachField',
+            flatten: true,
             fieldset: [
               { from: 'sourceOne', to: 'targetOne' },
               { from: 'sourceTwo', to: 'targetTwo' },
@@ -85,12 +86,34 @@ describe('Unsuccessful validations of correct JSON mappings :(', () => {
     expect(result.valid).to.false;
   });
 
-  it("should find a JSON invalid if the fromEach block doesn't contain the mandatory field(s)", () => {
+  it('should find a JSON invalid if the fromEach block doesn\'t contain the mandatory field(s)', () => {
     const jsonToValidate = {
       fieldset: [
         {
           fromEach: {
             to: 'fromEachTargetField',
+            fieldset: [
+              {
+                from: 'this field',
+                to: 'that field'
+              }
+            ]
+          }
+        }
+      ]
+    };
+    const result = validateWithSchema(jsonToValidate);
+    expect(result.valid).to.false;
+  });
+
+  it ('should find a JSON invalid if the flatten mapping property is of the wrong type', () => {
+    const jsonToValidate = {
+      fieldset: [
+        {
+          fromEach: {
+            field: 'fromField',
+            to: 'fromEachTargetField',
+            flatten: 2,
             fieldset: [
               {
                 from: 'this field',


### PR DESCRIPTION
Introduced a new property 'flatten' of type boolean with the default being implicitly false. This new property may only belong to a fromEach mapping block and is valid only within that scope. If subsequent blocks also need to be flattened, the property may be set anew in each further nested fromEach mapping block.