### PR TITLE
44 format dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Let's say you have a JSON file which looks something like the following:
         {
           fieldOne: 1,
           fieldTwo: 2,
+          thisDate: '1981-03-10',
           lowLevel: [
             {
               fieldThree: 3,
@@ -69,6 +70,7 @@ And for some reason (only you can know) you'd like to have something like this i
           fieldOne: 1,
           fieldTwo: [2],
           newProp: '1 is not 2',
+          thatDate: '10/03/1981',
           fieldThree: 3,
           fieldFour: 4,
           that: {
@@ -99,7 +101,16 @@ const mapping = {
               {
                 to: 'newProp',
                 withTemplate: '${fieldOne} is not ${fieldTwo}'
-              }
+              },
+              {
+                from: 'thisDate',
+                to: 'otherDate',
+                via: {
+                    type: 'date',
+                    sourceFormat: 'yyyy-MM-dd',
+                    format: 'dd/MM/yyyy'
+                }
+              },
               {
                 fromEach: {
                   field: 'lowLevel',
@@ -153,6 +164,8 @@ Woah! easy there, pilgrim! Let's break it down actually and take it from top to 
 9. The `toArray` property defines whether the referenced value from the source shall be placed into an array in the target object. This might come handy when you want to perform further processing on the transformed json and need to have arrays for the particular properties.
 
 10. The `withTemplate` property defines a template which may contain an arbitrary string with the possibility to embed references to props from the source. That comes handy if you want to construct a new property consisting of several fields from the source and maybe also some more text. In case the `withTemplate` prop is defined, **the `from` property must not exist in the same scope**, the two fields `withTemplate` and `from` are mutually exclusive. Another thing that changes if `withTemplate` is defined, is that the `to` property becomes mandatory and must be provided. This is because no implicit to field can be derived since the `from` property is not allowed in that case. Referenced properties may be nested, contain non-word characters, just like the props referenced by `from` are allowed to have.
+
+12. It is possible to define a format for values in the target object. Currently this is only possible for dates. In general formatting can be declared by using the `via` property which is an object that holds the type of the value, the source format to parse from and the target one to re-format to. Formatting is also possible in combination with the `withTemplate` property, though it is only possible to define one formatting option for all referenced values in the template. If you perhaps have 2 date values referenced both will be re-formatted with the format defined in the `via` property.
 
 That's a rather complex yet complete example since it makes use of the whole range of the currently implemented vocabulary of the DSL.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@perpk/json-xform",
-  "version": "1.0.3",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@perpk/json-xform",
-      "version": "1.0.3",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
+        "date-fns": "^2.28.0",
         "jsonpath": "^1.1.1",
         "jsonschema": "^1.4.0"
       },
@@ -1066,6 +1067,18 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dateformat": {
@@ -4781,6 +4794,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dateformat": {
       "version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "k.a.perperidis@gmail.com",
   "license": "ISC",
   "dependencies": {
+    "date-fns": "^2.28.0",
     "jsonpath": "^1.1.1",
     "jsonschema": "^1.4.0"
   },

--- a/schema/schema.js
+++ b/schema/schema.js
@@ -1,6 +1,15 @@
 const schema = {
   type: 'object',
   properties: {
+    via: {
+      id: '/Via',
+      type: 'object',
+      properties: {
+        type: { type: 'string', required: true, enum: ['date'] },
+        sourceFormat: { type: 'string', required: true },
+        format: { type: 'string', required: true }
+      }
+    },
     fieldset: {
       id: '/Fieldset',
       type: 'array',
@@ -12,6 +21,7 @@ const schema = {
           to: { type: 'string' },
           withTemplate: { type: 'string' },
           toArray: { type: 'boolean' },
+          via: { $ref: '/Via' },
           fromEach: {
             type: 'object',
             properties: {

--- a/test/formattingUtils.test.js
+++ b/test/formattingUtils.test.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai');
+const { describe, it } = require('mocha');
+const { createFormatter, dateFormatter } = require('../utils/formattingUtils');
+
+describe('The expected formatter is returned', () => {
+  it('should return the requested formatter', () => {
+    [{ type: 'date', formatter: dateFormatter }].forEach((requested) => {
+      const returned = createFormatter(requested.type);
+      expect(returned.toString()).to.equal(requested.formatter.toString());
+    });
+  });
+
+  it('should fail with the expected error message if an unknown type is provided', () => {
+    expect(() => createFormatter('lalala')).to.throw(
+      "There's no type named lalala known currently"
+    );
+  });
+});

--- a/test/mapping.dataFormat.test.js
+++ b/test/mapping.dataFormat.test.js
@@ -1,0 +1,175 @@
+const { expect } = require('chai');
+const { describe, it } = require('mocha');
+
+const { mapToNewObject } = require('../utils/mapping');
+
+describe('Reformat a date from the source', () => {
+  it('should reformat with the given format in the mapping', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'dateField',
+          to: 'anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/mm/yyyy',
+            sourceFormat: 'yyyy-dd-mm'
+          }
+        }
+      ]
+    };
+    const source = {
+      dateField: '1981-10-03'
+    };
+    const target = {
+      anotherDatefield: '10/03/1981'
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it('should reformat properly also when time is provided', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'dateField',
+          to: 'anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/MM/yyyy p',
+            sourceFormat: 'yyyy-dd-MM HH:mm:ss'
+          }
+        }
+      ]
+    };
+    const source = {
+      dateField: '1981-10-03 17:25:00'
+    };
+    const target = {
+      anotherDatefield: '10/03/1981 5:25 PM'
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it('should format dates referenced in a template', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          to: 'template',
+          withTemplate: 'It was on the ${theDate} not ${theOtherDate}',
+          via: {
+            type: 'date',
+            format: 'dd/MM/yyyy',
+            sourceFormat: 'yyyy-dd-MM'
+          }
+        }
+      ]
+    };
+    const source = {
+      theDate: '1981-10-03',
+      theOtherDate: '1982-12-12'
+    };
+    const target = {
+      template: 'It was on the 10/03/1981 not 12/12/1982'
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it('should format dates from chained prop references', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'property.dateField',
+          to: 'anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/MM/yyyy p',
+            sourceFormat: 'yyyy-dd-MM HH:mm:ss'
+          }
+        }
+      ]
+    };
+    const source = {
+      property: {
+        dateField: '1981-10-03 17:25:00'
+      }
+    };
+    const target = {
+      anotherDatefield: '10/03/1981 5:25 PM'
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it('should format dates into nested properties in target object', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'dateField',
+          to: 'property.anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/mm/yyyy',
+            sourceFormat: 'yyyy-dd-mm'
+          }
+        }
+      ]
+    };
+    const source = {
+      dateField: '1981-10-03'
+    };
+    const target = {
+      property: {
+        anotherDatefield: '10/03/1981'
+      }
+    };
+    const newObject = mapToNewObject(source, xFormTemplate);
+    expect(newObject).to.eqls(target);
+  });
+
+  it('should fail if a wrongly formatted date is provided as input', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'dateField',
+          to: 'property.anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/mm/yyyy',
+            sourceFormat: 'yyyy-dd-mm'
+          }
+        }
+      ]
+    };
+    const source = {
+      dateField: '1981-10'
+    };
+    const errorMsg =
+      'Invalid time value error occured when trying to format 1981-10 with dd/mm/yyyy';
+    expect(() => mapToNewObject(source, xFormTemplate)).to.throw(errorMsg);
+  });
+
+  it('should fail if a wrongly formatted date is provided as input', () => {
+    const xFormTemplate = {
+      fieldset: [
+        {
+          from: 'dateField',
+          to: 'property.anotherDatefield',
+          via: {
+            type: 'date',
+            format: 'dd/mm/yyyy',
+            sourceFormat: 'yyyy-dd-sdadsad'
+          }
+        }
+      ]
+    };
+    const source = {
+      dateField: '1981-10'
+    };
+    const errorMsg =
+      'Invalid time value error occured when trying to format 1981-10 with dd/mm/yyyy';
+    expect(() => mapToNewObject(source, xFormTemplate)).to.throw(errorMsg);
+  });
+});

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -59,6 +59,25 @@ describe('Successful validations of correct JSON mappings :)', () => {
     const result = validateWithSchema(complexJsonToValidate);
     expect(result.valid).to.true;
   });
+
+  it('should validate a mapping with the "via" formatting property successfully', () => {
+    const jsonToValidate = {
+      fieldset: [
+        {
+          from: 'field',
+          to: 'another',
+          via: {
+            type: 'date',
+            format: 'dd/mm/yyyy',
+            sourceFormat: 'yyyy-mm-dd'
+          }
+        }
+      ]
+    };
+
+    const result = validateWithSchema(jsonToValidate);
+    expect(result.valid).to.true;
+  });
 });
 
 describe('Unsuccessful validations of correct JSON mappings :(', () => {
@@ -233,5 +252,57 @@ describe('Unsuccessful validations of correct JSON mappings :(', () => {
 
     const result = validateWithSchema(jsonToValidate);
     expect(result.valid).to.true;
+  });
+
+  it('should find a JSON invalid if there are uknown types in the via object', () => {
+    const jsonToValidate = {
+      fieldset: [
+        {
+          from: 'field',
+          to: 'another',
+          via: {
+            type: 'lala',
+            format: '##.###'
+          }
+        }
+      ]
+    };
+
+    const result = validateWithSchema(jsonToValidate);
+    expect(result.valid).to.false;
+  });
+
+  it ('should find a JSON invalid if the type missing in the via object', () => {
+    const jsonToValidate = {
+      fieldset: [
+        {
+          from: 'field',
+          to: 'another',
+          via: {
+            format: '##.###'
+          }
+        }
+      ]
+    };
+
+    const result = validateWithSchema(jsonToValidate);
+    expect(result.valid).to.false;
+  });
+
+  it ('should find a JSON invalid if the format is missing in the via object', () => {
+    const jsonToValidate = {
+      fieldset: [
+        {
+          from: 'field',
+          to: 'another',
+          via: {
+            type: 'lala',
+          }
+        }
+      ]
+    };
+
+    const result = validateWithSchema(jsonToValidate);
+    expect(result.valid).to.false;
   });
 });

--- a/utils/constructTarget.js
+++ b/utils/constructTarget.js
@@ -1,24 +1,46 @@
-const addPropToTarget = (target, property, propertyValue, toArray = false) => {
+const { formatPropValueIfNecessary } = require('./formattingUtils');
+
+const addPropToTarget = (
+  target,
+  property,
+  propertyValue,
+  toArray = false,
+  via = null
+) => {
   const newTarget = { ...target };
   if (property.indexOf('.') >= 0) {
     const parts = property.split('.');
-    addPropRecursive(parts, newTarget, propertyValue, toArray);
+    addPropRecursive(parts, newTarget, propertyValue, toArray, via);
   } else if (!newTarget[property]) {
-    newTarget[property] = toArray ? [propertyValue] : propertyValue;
+    const formattedValue = formatPropValueIfNecessary(propertyValue, via);
+    newTarget[property] = toArray ? [formattedValue] : formattedValue;
   }
   return newTarget;
 };
 
-const addPropRecursive = (elems, target, value, toArray = false) => {
+const addPropRecursive = (
+  elems,
+  target,
+  value,
+  toArray = false,
+  via = null
+) => {
   let current = elems.shift();
   if (!current) {
-    target = toArray ? [value] : value;
+    const formattedValue = formatPropValueIfNecessary(value, via);
+    target = toArray ? [formattedValue] : formattedValue;
     return target;
   }
   if (!target[current]) {
     target[current] = {};
   }
-  target[current] = addPropRecursive(elems, target[current], value, toArray);
+  target[current] = addPropRecursive(
+    elems,
+    target[current],
+    value,
+    toArray,
+    via
+  );
   return target;
 };
 

--- a/utils/formattingUtils.js
+++ b/utils/formattingUtils.js
@@ -1,0 +1,31 @@
+const dFormat = require('date-fns/format');
+const parse = require('date-fns/parse');
+
+const createFormatter = (type) => {
+  switch (type) {
+    case 'date':
+      return dateFormatter;
+    default:
+      throw `There's no type named ${type} known currently`;
+  }
+};
+
+const dateFormatter = (value, format, sourceFormat) => {
+  try {
+    const date = parse(value, sourceFormat, new Date());
+    return dFormat(date, format);
+  } catch (ex) {
+    throw `${ex.message} error occured when trying to format ${value} with ${format}`;
+  }
+};
+
+const formatPropValueIfNecessary = (propValue, via) => {
+  if (!via) {
+    return propValue;
+  }
+
+  const formatter = createFormatter(via.type);
+  return formatter(propValue, via.format, via.sourceFormat);
+};
+
+module.exports = { formatPropValueIfNecessary, createFormatter, dateFormatter };

--- a/utils/mapping.js
+++ b/utils/mapping.js
@@ -2,7 +2,11 @@ const { readJSON } = require('./ioUtils');
 const { addPropToTarget } = require('./constructTarget');
 const { querySingleProp, queryAll } = require('./queryJson');
 const { validateWithSchema, validationUtil } = require('../schema/validator');
-const { pickTemplateVarsFromString, wrapInVarBraces } = require('./stringUtils');
+const {
+  pickTemplateVarsFromString,
+  wrapInVarBraces
+} = require('./stringUtils');
+const { formatPropValueIfNecessary } = require('./formattingUtils');
 
 const commands = {
   FIELDSET: 'fieldset',
@@ -129,8 +133,14 @@ const traverseFieldset = (source, fieldsetTemplate, target) => {
       if (!fromValue) {
         return;
       }
-      
-      let currentTarget = addPropToTarget(target, to, fromValue, item.toArray);
+
+      let currentTarget = addPropToTarget(
+        target,
+        to,
+        fromValue,
+        item.toArray,
+        item.via
+      );
       target = { ...target, ...currentTarget };
     }
 
@@ -144,10 +154,13 @@ const traverseFieldset = (source, fieldsetTemplate, target) => {
         });
         let resolvedTemplate = item.withTemplate;
         for (const [name, value] of Object.entries(pairs)) {
-          resolvedTemplate = resolvedTemplate.replace(wrapInVarBraces(name), value);
+          resolvedTemplate = resolvedTemplate.replace(
+            wrapInVarBraces(name),
+            formatPropValueIfNecessary(value, item.via)
+          );
         }
         let currentTarget = addPropToTarget(target, to, resolvedTemplate);
-        target = {...target, ...currentTarget};
+        target = { ...target, ...currentTarget };
       } else {
         let currentTarget = addPropToTarget(target, to, item.withTemplate);
         target = { ...target, ...currentTarget };


### PR DESCRIPTION
Fixes #44 

- Re-Format dates from a source object to a target one.
- Perform formatting also for cases where nesting is available in either source or target.
- Perform formatting also for values which are referenced in templates.